### PR TITLE
Selecting the "Start release" configuration option by default

### DIFF
--- a/src/main/resources/com/xebialabs/xlrelease/ci/XLReleaseNotifier/config.jelly
+++ b/src/main/resources/com/xebialabs/xlrelease/ci/XLReleaseNotifier/config.jelly
@@ -31,7 +31,7 @@
          </f:entry>
 
      <f:entry title="${%StartRelease}" field="startRelease">
-            <f:checkbox/>
+            <f:checkbox default="true"/>
      </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
**Note:** change of default behaviour

In an automation environment where releases are being created
automatically, it is more likely that the release is also
intended to be *started* when created.

/cc @jdewinne @mkotsur @mathieubigorne 