### PR TITLE
REL-2315: Removing the condition that releases are only created if there are variables or 'startRelease' is checked

### DIFF
--- a/src/main/java/com/xebialabs/xlrelease/ci/XLReleaseNotifier.java
+++ b/src/main/java/com/xebialabs/xlrelease/ci/XLReleaseNotifier.java
@@ -106,12 +106,14 @@ public class XLReleaseNotifier extends Notifier {
 
         // createRelease
         Release release = null;
-        if (variables != null || startRelease)
+        if (variables != null || startRelease) {
             release = createRelease(template,resolvedVersion, resolvedVariables, deploymentListener);
 
-        // startRelease
-        if (startRelease)
-            startRelease(release, template,resolvedVersion, deploymentListener);
+            // startRelease
+            if (startRelease) {
+                startRelease(release, template,resolvedVersion, deploymentListener);
+            }
+        }
 
         return true;
     }

--- a/src/main/java/com/xebialabs/xlrelease/ci/XLReleaseNotifier.java
+++ b/src/main/java/com/xebialabs/xlrelease/ci/XLReleaseNotifier.java
@@ -106,13 +106,11 @@ public class XLReleaseNotifier extends Notifier {
 
         // createRelease
         Release release = null;
-        if (variables != null || startRelease) {
-            release = createRelease(template,resolvedVersion, resolvedVariables, deploymentListener);
+        release = createRelease(template, resolvedVersion, resolvedVariables, deploymentListener);
 
-            // startRelease
-            if (startRelease) {
-                startRelease(release, template,resolvedVersion, deploymentListener);
-            }
+        // startRelease
+        if (startRelease) {
+            startRelease(release, template, resolvedVersion, deploymentListener);
         }
 
         return true;


### PR DESCRIPTION
Confirmed with @jdewinne that it's not clear why this behaviour was in place: it basically meant that it was impossible to create a release without variables without also starting it.

This PR changes the behaviour to always create a release, and start it if the `startRelease` option is checked.

**Before:**
* release without vars without `startRelease`: nothing created

![image](https://cloud.githubusercontent.com/assets/223702/6624366/2c463dfa-c8bf-11e4-8003-a4484011fefa.png)

* release without vars with `startRelease`: release created and started
* release with vars without `startRelease`: release created
* release with vars without `startRelease` and not enough vars: nothing created
* release with vars with `startRelease`: release created and started

**After:**
* release without vars without `startRelease`: release created

![image](https://cloud.githubusercontent.com/assets/223702/6624355/21c40682-c8bf-11e4-815a-efb0b6986a64.png)

* release without vars with `startRelease`: release created and started
* release with vars without `startRelease`: release created
* release with vars without `startRelease` and not enough vars: release creation fails

![image](https://cloud.githubusercontent.com/assets/223702/6624349/17479980-c8bf-11e4-91e0-7c8d28233b9a.png)

* release with vars with `startRelease`: release created and started

The main "breaking" change is that the code will now fail a build if it attempts to create a release without specifying all required variables. But this _also_ seems like an improvement to me.

/cc @byaminov 